### PR TITLE
Fix incorrect handling of cookies across client group changes.

### DIFF
--- a/server/src/data.ts
+++ b/server/src/data.ts
@@ -8,7 +8,7 @@ export type SearchResult = {
 
 export type ClientGroupRecord = {
   id: string;
-  cvrVersion: number;
+  cvrVersion: number | null;
   clientVersion: number;
 };
 
@@ -269,7 +269,7 @@ export async function getClientGroupForUpdate(
   return (
     prevClientGroup ?? {
       id: clientGroupID,
-      cvrVersion: 0,
+      cvrVersion: null,
       clientVersion: 0,
     }
   );

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -20,9 +20,10 @@ export async function createSchemaVersion1(executor: Executor) {
     "insert into replicache_meta (key, value) values ('schemaVersion', '1')",
   );
 
+  // cvrversion is null until first pull initializes it.
   await executor(`create table replicache_client_group (
     id varchar(36) primary key not null,
-    cvrversion integer not null,
+    cvrversion integer null,
     clientversion integer not null,
     lastmodified timestamp(6) not null
     )`);


### PR DESCRIPTION
# Problem

Replicache cookies are shared among client groups. In certain cases, you can see a new client group with a cookie != null. In particular this happens when the set of mutators is changed. Replicache spawns a new ClientGroup because pending mutations can't be shared across ClientGroups that don't have the same mutators. But Replicache reuses the existing client view (and cookie) in that case to avoid re-downloading the world.

todo-row-versioning forgot this can happen and assumed that cookies were always per-client-group. This had two consequences:

* In this upgrade case, the prev cookie would not be found, resulting in a fresh download.
* In this upgrade case, the cookie would reset at zero, causing Replicache to complain and drop the pull response.

# Solution

* As cookies can be shared across ClientGroups, they need to be scoped by the creating CG. Expand the cookie to include the creating CG.
* Cookies still need to be ordered per-ClientGroup however, so use the special `order` field that cookies support, so transmit cookie as `{order: $cvrVersion, clientGroupID: $clientGroupID}`.
* Rather than initializing ClientGroupRecord.cvrVersion to zero, initialize to a `null` sentinel. In pull, if base ClientGroup's cvrVersion is `null`, set the next cvrVersion to the incoming cookie's order field if one exists, otherwise zero as before. This ensures for each client group cookies only increase.

# Testing

Manually tested by changing mutators to cause a ClientGroup change and observing the logging on both client and server.

Before, when doing this I observed an error on the client about the cookie going down. After I don't oberve this error.

Also, before I observe on the server in this case the prevCVR is not found, but after it is found.